### PR TITLE
Provide success message for upgrade

### DIFF
--- a/roles/unicorn/templates/unicorn_init.j2
+++ b/roles/unicorn/templates/unicorn_init.j2
@@ -51,7 +51,7 @@ force-stop)
   echo >&2 "Not running"
   ;;
 restart|reload)
-  sig HUP && echo reloaded OK && exit 0
+  sig HUP && echo "reloaded OK" && exit 0
   echo >&2 "Couldn't reload, starting '$CMD' instead"
   run "$CMD"
   ;;
@@ -70,6 +70,7 @@ upgrade)
       echo >&2 "$OLD_PIN still exists after $TIMEOUT seconds"
       exit 1
     fi
+    echo "upgraded OK"
     exit 0
   fi
   echo >&2 "Couldn't upgrade, starting '$CMD' instead"


### PR DESCRIPTION
Provide success message for upgrade task, so that `fairfood/script/deploy` can determine success or not.