### PR TITLE
Block scanning for scripts efficiently

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -131,6 +131,12 @@ nginx_sites_available:
       gzip_disable "msie6";
 
       try_files $uri/index.html $uri @unicorn;
+
+      # Block scanning for scripts efficiently.
+      location ~ \.php$ {
+        return 404;
+      }
+
       location @unicorn {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;


### PR DESCRIPTION
https://github.com/ceresfairfood/fairfood-issues/issues/517

There are over 100 requests per month for PHP scripts. This rule should save us some resources and unclutter our log files.

If a user accidentally went to a URL ending in `.php` they will see a quicker but less beautiful error page.

Before:
![Screenshot from 2020-11-06 10-07-30](https://user-images.githubusercontent.com/3524483/98306431-f3b51680-2017-11eb-8237-ed9a7e32cdeb.png)

After:
![Screenshot from 2020-11-06 10-07-45](https://user-images.githubusercontent.com/3524483/98306450-fa438e00-2017-11eb-8f66-f845b81ac254.png)

But since this is extremely unlikely, I wouldn't add complexity and server load to our application to show something better here. This can be improved if we get that feedback though.

This has been added to the staging server.