### PR TITLE
Forward system messages to IT email address

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -25,8 +25,8 @@ domain: "{{ inventory_hostname }}"
 metabase_domain: "metabase.ceresfairfood.org.au"
 
 https: false
-
 rails_env: "staging"
+email_it: "ceresfairfood+it@openfoodnetwork.org.au"
 
 #----------------------------------------------------------------------
 # Database variables

--- a/roles/mail/tasks/main.yml
+++ b/roles/mail/tasks/main.yml
@@ -16,3 +16,11 @@
     line: "inet_interfaces = loopback-only"
     state: present
   notify: Reload postfix
+
+- name: Forward system messages to IT email address
+  lineinfile:
+    create: yes
+    dest: ~/.forward
+    regexp: "root"
+    line: "{{ email_it }}, /root/mailbox"
+    state: present


### PR DESCRIPTION
I came across this old issue and thought 'hey, that sounds easy', so I did it.

However it sends an email everytime I accidentally type `sudo` as the fairfood user. Hopefully that will be less frequent if I get in the habit of switching to `root` anyway..

ceresfairfood/fairfood-install#13
