### PR TITLE
Avoid mysqldump warning about database prefix

### DIFF
--- a/roles/mysql/templates/my.cnf
+++ b/roles/mysql/templates/my.cnf
@@ -1,4 +1,6 @@
 [client]
 user = "{{ db_user }}"
 password = "{{ lookup('password', 'credentials/' + ansible_host + '/mysqlpassword length=15') }}"
+
+[mysql]
 database = "{{ db_name }}"


### PR DESCRIPTION
We saw this:

    Info: Using unique option prefix 'database' is error-prone and can break in the future. Please use the full name 'databases' instead.
    Warning: mysqldump: ignoring option '--databases' due to invalid value 'fairfood_production'

We thought that db2fog was outdated but the offending option came from
out own .my.cnf file. It contained the `database` option so that we
don't have to type the database name to connect on the console.

But while the `mysql` command supports that option, `mysqldump` doesn't
and was complaining about it. This problem is solved by being more
specific in the config file.

[ceresfairfood/fairfood-issues#](https://github.com/ceresfairfood/fairfood-issues/issues/2125)
