### PR TITLE
Always upgrade unicorn instead of just reloading

### DIFF
--- a/roles/fairfood/templates/post-receive.j2
+++ b/roles/fairfood/templates/post-receive.j2
@@ -16,7 +16,7 @@ APP_ROOT="$(pwd)"
 export RAILS_ENV="{{ rails_env }}"
 
 upgrade_application() {
-  local action="${1:-reload}"
+  local action="${1:-upgrade}"
 
   echo "RAILS_ENV=$RAILS_ENV"
 
@@ -62,17 +62,9 @@ upgrade_application() {
 while read oldrev newrev refname; do
   echo "HEAD was at $oldrev"
   if [ "$refname" = "refs/heads/master" ]; then
-  # Check if ruby or gems changed
-  if git diff --quiet "$newrev" -- ".ruby-version" "Gemfile.lock"; then
-    # no changes
-    action="reload"
-  else
-    # we need to start a new master process
-    action="upgrade"
-  fi
-  # Checkout the new revision
-  git reset --hard "$newrev"
-  upgrade_application "$action"
+    # Checkout the new revision
+    git reset --hard "$newrev"
+    upgrade_application
   fi
 done
 


### PR DESCRIPTION
We tried to be clever and only reload unicorn when no gems changed. It's
faster. But that logic can fail if a previous deployment failed for
another reason. Let's be safe an always upgrade.

ceresfairfood/fairfood-issues#2183

I changed this on staging and production.