### PR TITLE
Simplify vagrant hosts config

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Tips for testing individual changes:
  * Go straight to specific task: `--start-at-task='<name of task>'`
  * Run one at a time: `--step`
 
- Eg: `ansible-playbook -i hosts -l vagrant-virtualbox site.yml --step --start-at-task='Install configuration files'`
+ Eg: `ansible-playbook -i hosts -l vagrant site.yml --step --start-at-task='Install configuration files'`
 
 ### Snapshots
 It's handy to take snapshots to quickly revert back to. Eg:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,10 @@ Vagrant.configure(2) do |config|
   config.vm.network "forwarded_port", guest: 443, host: 4433
   config.vm.network "forwarded_port", guest: 3000, host: 3001 # Metabase (bypass nginx)
 
+  # Use a shared private key for all providers.
+  #   ~/.vagrant.d/insecure_private_key
+  config.ssh.insert_key = false
+
   config.vm.provider :libvirt do |box|
     box.memory = 1536
     box.nic_model_type = "virtio"

--- a/collectd-wormly.yml
+++ b/collectd-wormly.yml
@@ -5,7 +5,6 @@
 - name: nginx_status for collectd-wormly
   hosts:
     - vagrant
-    - vagrant-virtualbox
     - staging
     - production # This was exected on prod but failed due to invalid config in fairfood_beta. Manually completed after disabling fairfood_beta.
 

--- a/hosts
+++ b/hosts
@@ -3,8 +3,7 @@
 ## Production hosts should have `https=true` and `developer_email` set for Letsencrypt.
 
 [local]
-vagrant ansible_port=2222 ansible_host=127.0.0.1 ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/libvirt/private_key ansible_ssh_common_args='-o StrictHostKeyChecking=no'
-vagrant-virtualbox ansible_port=2222 ansible_host=127.0.0.1 ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+vagrant ansible_host=127.0.0.1 ansible_port=2222 ansible_user=vagrant ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key ansible_ssh_common_args='-o StrictHostKeyChecking=no'
 
 [staging]
 staging.ceresfairfood.org.au https=true developer_email=maikel@openfoodnetwork.org.au

--- a/metabase.yml
+++ b/metabase.yml
@@ -9,7 +9,6 @@
 - name: Install Metabase
   hosts:
     - vagrant
-    - vagrant-virtualbox
     - staging
 
   roles:


### PR DESCRIPTION
This is a breaking change. Your old VM will have a different SSH key
to this config. You can override it on the command line or create a new
VM.

I'm currently working on ofn-install and found this config much easier.
