### PR TITLE
Configure bundler via its new API

### DIFF
--- a/roles/fairfood/templates/post-receive.j2
+++ b/roles/fairfood/templates/post-receive.j2
@@ -25,7 +25,10 @@ upgrade_application() {
   ./script/install-bundler
 
   # Install the required gems
-  bundle --path "$HOME/.gem" --deployment --without "development" "test" | grep -v '^Using'
+  bundle config set --local deployment "true"
+  bundle config set --local path "$HOME/.gem"
+  bundle config set --local without "development test"
+  bundle install | grep -v '^Using'
 
   ./script/precompile-assets
 


### PR DESCRIPTION
Future versions will stop supporting the extra parameters. This avoids
deprecation warnings.

I noticed this when deploying Ruby 3 with new bundler.

I changed this on staging and production already.