### PR TITLE
Suppress bundler's "Using" messages

### DIFF
--- a/roles/fairfood/templates/post-receive.j2
+++ b/roles/fairfood/templates/post-receive.j2
@@ -28,7 +28,8 @@ upgrade_application() {
   bundle config set --local deployment "true"
   bundle config set --local path "$HOME/.gem"
   bundle config set --local without "development test"
-  bundle install | grep -v '^Using'
+  bundle config set --local suppress_install_using_messages "true"
+  bundle install
 
   ./script/precompile-assets
 


### PR DESCRIPTION
Instead of filtering them.

I just had a look at `man bundle-config` out of curiosity and found this.