### PR TITLE
Enable mariadb logging to file

### DIFF
--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Enable mariadb error logging
   lineinfile:
     dest: /etc/mysql/mariadb.conf.d/50-server.cnf
-    regexp: "^log_error ?="
+    regexp: "^#?log_error ?="
     line: "log_error = /var/log/mysql/error.log"
     state: present
 

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -10,13 +10,11 @@
     state: present
 
 - name: Enable mariadb error logging
-  replace:
-    path: /etc/mysql/mariadb.conf.d/50-server.cnf
-    # Uncomment matching lines
-    regexp: '^#\s?(\s*){{ item }}(.+)$'
-    replace: '\1{{ item }}\2'
-  loop:
-    - 'log_error'
+  lineinfile:
+    dest: /etc/mysql/mariadb.conf.d/50-server.cnf
+    regexp: "^log_error ?="
+    line: "log_error = /var/log/mysql/error.log"
+    state: present
 
 - name: Ensure that service is started and enabled
   service:

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -9,6 +9,15 @@
     - python3-mysqldb # required by Ansible mysql_db
     state: present
 
+- name: Enable mariadb error logging
+  replace:
+    path: /etc/mysql/mariadb.conf.d/50-server.cnf
+    # Uncomment matching lines
+    regexp: '^#\s?(\s*){{ item }}(.+)$'
+    replace: '\1{{ item }}\2'
+  loop:
+    - 'log_error'
+
 - name: Ensure that service is started and enabled
   service:
     name: mariadb


### PR DESCRIPTION
Logging to help debug any future occurrences of:
ceresfairfood/fairfood-issues#2229

Tested and enabled on vagrant and staging. I've manually set on prod, and it will require a service restart. Will communicate with team and could schedule for this afternoon.


