### PR TITLE
Install libyaml-dev for Ruby 3.2

### DIFF
--- a/roles/fairfood-dependencies/tasks/main.yml
+++ b/roles/fairfood-dependencies/tasks/main.yml
@@ -28,6 +28,8 @@
     - memcached
     - monit
     - nginx
+    # For Ruby 3.2
+    - libyaml-dev
     # For the mysql2 gem
     - libmariadb-dev
     # For mimemagic / paperclip


### PR DESCRIPTION
New Rubies don't bundle libyaml any more. Instead they rely on the operating system to provide it which is more efficient. Just means that we need to install another dependency.

* https://github.com/ceresfairfood/fairfood/pull/1927
