### PR TITLE
Increase Unicorn and nginx timeouts

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -54,7 +54,7 @@ unicorn_log: "{{ log_path }}/unicorn.log"
 unicorn_pid: "{{ pid_path }}/unicorn.pid"
 unicorn_sock: "{{ sock_path }}/unicorn.sock"
 unicorn_workers: 3
-unicorn_timeout: 60
+unicorn_timeout: 140 # Allow SecurePay transactions to take up to 120 seconds
 
 
 #----------------------------------------------------------------------

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -116,6 +116,7 @@ nginx_sites_available:
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_redirect off;
         proxy_pass http://unicorn;
+        proxy_read_timeout {{ unicorn_timeout + 1 }};
       }
 
       location ~ ^/(assets)/ {
@@ -183,6 +184,7 @@ nginx_sites_available:
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_redirect off;
         proxy_pass http://unicorn;
+        proxy_read_timeout {{ unicorn_timeout + 1 }};
       }
 
       location ~ ^/(assets)/ {


### PR DESCRIPTION
* Closes ceresfairfood/fairfood-issues#2424

Deployed on staging:

```
TASK [unicorn : copy unicorn files] ********************************************************************************************************************************************************************************************************
ok: [staging.ceresfairfood.org.au] => (item={'src': 'unicorn_init.j2', 'dest': '/etc/init.d/unicorn_fairfood', 'mode': '0744', 'owner': 'fairfood', 'group': 'fairfood'})
changed: [staging.ceresfairfood.org.au] => (item={'src': 'unicorn.rb.j2', 'dest': '/srv/fairfood/unicorn.rb', 'mode': '0744', 'owner': 'fairfood', 'group': 'fairfood'})

...

TASK [jdauphant.nginx : Create the configurations for sites] *******************************************************************************************************************************************************************************
changed: [staging.ceresfairfood.org.au] => (item={'key': 'default', 'value': ["# Default port settings\nlisten 80 deferred default_server;\nlisten [::]:80 deferred;\nlisten 443 ssl deferred default_server;\nlisten [::]:443 ssl deferred default_server;\n\n# Defaults for any server_names not specified elsewhere\n# nginx requires a cert for ssl ports, even though we're not responding:\ninclude snippets/snakeoil.conf; # self-signed certificate\n\naccess_log off;\n# nginx code to close the connection without sending any data:\nreturn 444;\n"]})
changed: [staging.ceresfairfood.org.au] => (item={'key': 'fairfood_http', 'value': ['listen 80;\nlisten [::]:80;\nserver_name staging.ceresfairfood.org.au;\n\nadd_header X-Content-Type-Options nosniff;\nadd_header X-Xss-Protection "1; mode=block";\nadd_header X-Frame-Options DENY;\n#add_header Content-Security-Policy "default-src self";\n\n# For certbot automatic renewal\nlocation \'/.well-known/acme-challenge\' {\n  default_type "text/plain";\n  root /etc/letsencrypt/webrootauth;\n}\n\nlocation / {\n  return 301 https://$server_name$request_uri;\n}\n']})
changed: [staging.ceresfairfood.org.au] => (item={'key': 'fairfood_https', 'value': ['listen 443 ssl;\nlisten [::]:443 ssl;\nserver_name staging.ceresfairfood.org.au;\nroot "/srv/fairfood/current/public";\n\nssl_certificate      /etc/letsencrypt/live/staging.ceresfairfood.org.au/fullchain.pem;\nssl_certificate_key  /etc/letsencrypt/live/staging.ceresfairfood.org.au/privkey.pem;\n\ninclude /etc/letsencrypt/options-ssl-nginx.conf;\nssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;\n\nadd_header X-Content-Type-Options nosniff;\nadd_header X-Xss-Protection "1; mode=block";\nadd_header X-Frame-Options DENY;\nadd_header Strict-Transport-Security "max-age=31536000";\n\ngzip on;\ngzip_disable "msie6";\n\ntry_files $uri/index.html $uri @unicorn;\n\n# Block scanning for scripts efficiently.\nlocation ~ \\.php$ {\n  return 404;\n}\n\nlocation @unicorn {\n  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n  proxy_set_header Host $host;\n  proxy_set_header X-Forwarded-Proto $scheme;\n  proxy_redirect off;\n  proxy_pass http://unicorn;\n  proxy_read_timeout 141;\n}\n\nlocation ~ ^/(assets)/ {\n  gzip_static on;\n  expires max;\n  add_header Cache-Control public;\n}\n\nerror_page 500 502 503 504 /500.html;\nclient_max_body_size 4G;\nkeepalive_timeout 60;\n']})
```

Test web requests (before and after https://github.com/ceresfairfood/fairfood/pull/1967)
* with 61 second sleep: completes successfully ✅ 
* with 141 second sleep: executes until 140, then returns 500 error ✅

![Screen Shot 2023-08-24 at 11 51 53 am](https://github.com/ceresfairfood/fairfood-install/assets/4188088/17753c21-c965-4688-9a50-2e94c717f55e)

Unicorn admits to bloodshed: 
```
E, [2023-08-24T12:14:59.615647 #3889725] ERROR -- : worker=2 PID:3889729 timeout (141s > 140s), killing
```

Nginx log has no (new) errors.