### PR TITLE
Set journal log size limit

### DIFF
--- a/roles/config/README.md
+++ b/roles/config/README.md
@@ -1,0 +1,1 @@
+General system config to keep things running smoothly.

--- a/roles/config/handlers/main.yml
+++ b/roles/config/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Reload journald
+  service: name=systemd-journald state=restarted
+  become: yes

--- a/roles/config/tasks/main.yml
+++ b/roles/config/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: "Set journal log size limit" # to avoid hard drive filling up!
+  lineinfile:
+    path: /etc/systemd/journald.conf
+    regexp: '^#\s*SystemMaxUse='
+    line: 'SystemMaxUse=100M'
+  notify: Reload journald
+  become: yes

--- a/site.yml
+++ b/site.yml
@@ -7,6 +7,8 @@
     - role: admin-users
       become: yes
 
+    - role: config
+
     - role: fairfood-dependencies
       become: yes
 


### PR DESCRIPTION
to avoid hard drive filling up! 

This config freed up about 1.3gb on staging. 
I manually ran the new tasks on staging.
I'll manually apply to prod once merged.

This might be worth doing for the Ubuntu OFN servers too.
