### PR TITLE
Allow CORS for any subdomains

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -168,6 +168,10 @@ nginx_sites_available:
       add_header X-Frame-Options DENY;
       add_header Strict-Transport-Security "max-age=31536000";
 
+      # Allow CORS with whitelisted domains
+      add_header Access-Control-Allow-Origin $allow_origin; # See map allow_origin defined below
+      add_header Vary Origin; # indicates that responses differ based on the value of the Origin request header.
+
       gzip on;
       gzip_disable "msie6";
 
@@ -268,3 +272,12 @@ nginx_configs:
     # For running Unicorn behind nginx, it is recommended to set “fail_timeout=0” for in your nginx configuration
     # https://www.rubydoc.info/gems/unicorn/Unicorn%2FConfigurator:timeout
     - upstream unicorn { server unix:{{ unicorn_sock }} fail_timeout=0; }
+
+  upgrade:
+    - |
+      # Whitelist for any subdomains and local dev
+      map $http_origin $allow_origin {
+        ~^https?://(.*\.)?ceresfairfood.org.au(:\d+)?$ $http_origin;
+        ~^https?://(.*\.)?localhost(:\d+)?$ $http_origin;
+        default "";
+      }

--- a/site.yml
+++ b/site.yml
@@ -38,6 +38,7 @@
           fairfood: "{{ nginx_sites_available.fairfood_http }}"
       become: yes
       when: not https
+      tag: nginx
 
     - role: jdauphant.nginx
       vars:
@@ -47,9 +48,11 @@
           fairfood_https: "{{ nginx_sites_available.fairfood_https }}"
       become: yes
       when: https |bool
+      tag: nginx
 
     - role: nginx
       become: yes
+      tag: nginx
 
     - role: fairfood
       become: yes


### PR DESCRIPTION
Required in order to access products.json on the Wordpress site, to provide products search with autocomplete.

- ceresfairfood/fairfood-issues#2440

I think deploying with ansible is too risky (may affect WP site), so will manually copy in these changes on prod.
