### PR TITLE
Set up rate limitting with Geoip database

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -288,6 +288,7 @@ nginx_configs:
       }
 
   geoip:
-    - geoip2 /var/lib/GeoIP/GeoLite2-Country.mmdb { $geoip2_data_country_iso_code country iso_code; }
-    - map $geoip2_data_country_iso_code  $geo_outside_aus { default "outside"; AU ""; }
-    - limit_req_zone $geo_outside_aus zone=overseas:10m rate=150r/m;
+    - |
+      geoip2 /var/lib/GeoIP/GeoLite2-Country.mmdb { $geoip2_data_country_iso_code country iso_code; }
+      map $geoip2_data_country_iso_code  $geo_outside_aus { default "outside"; AU ""; }
+      limit_req_zone $geo_outside_aus zone=overseas:10m rate=150r/m;

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -241,6 +241,8 @@ nginx_sites_available:
       gzip on;
       gzip_disable "msie6";
 
+      limit_req zone=overseas burst=70 delay=3;
+
       # Metabase
       location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -284,3 +286,8 @@ nginx_configs:
         ~^https?://(.*\.)?localhost(:\d+)?$ $http_origin;
         default "";
       }
+
+  geoip:
+    - geoip2 /var/lib/GeoIP/GeoLite2-Country.mmdb { $geoip2_data_country_iso_code country iso_code; }
+    - map $geoip2_data_country_iso_code  $geo_outside_aus { default "outside"; AU ""; }
+    - limit_req_zone $geo_outside_aus zone=overseas:10m rate=150r/m;

--- a/roles/geolimit/tasks/main.yml
+++ b/roles/geolimit/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Add maxmind repository
+  apt_repository:
+    repo: ppa:maxmind/ppa
+    codename: focal # Ubuntu 20 / Debian 11
+    # codename: noble # Ubuntu 24 / Debian 13
+
+- name: Install system dependencies of the fairfood application
+  apt:
+    pkg:
+    - libnginx-mod-http-geoip2
+    - geoipupdate

--- a/site.yml
+++ b/site.yml
@@ -36,6 +36,13 @@
       when: https |bool
       tags: certbot
 
+    # After the installation you need to copy a license key to:
+    #   /etc/GeoIP.conf
+    # Then you can run `geoipupdate` to download the database.
+    # Otherwise the nginx config is not valid.
+    - role: geolimit
+      become: yes
+
     - role: jdauphant.nginx
       vars:
         nginx_sites:

--- a/site.yml
+++ b/site.yml
@@ -42,6 +42,7 @@
     # Otherwise the nginx config is not valid.
     - role: geolimit
       become: yes
+      tags: geolimit
 
     - role: jdauphant.nginx
       vars:


### PR DESCRIPTION
https://github.com/ceresfairfood/fairfood-issues/issues/2615

It restricts overseas traffic to 70 requests at a time and then delays to a rate our app can easily handle. When sending 80 requests from overseas, 9 got dropped straight away and 71 were processed within 30 seconds while the app was still responsive and fast from within Australia.

One problem I was facing here is the secret license key. How do we supply that? We currently don't have a mechanism for secrets.