### PR TITLE
Don't install code_quality gems on servers 

### DIFF
--- a/roles/fairfood/tasks/main.yml
+++ b/roles/fairfood/tasks/main.yml
@@ -46,15 +46,7 @@
   with_items:
     - { src: "post-receive.j2", dest: "{{ build_path }}/.git/hooks/post-receive" }
     - { src: "database.yml.j2", dest: "{{ config_path }}/database.yml" }
-
-- name: Configure Bundler
-  shell:
-    chdir: "{{ build_path }}"
-    cmd: |
-      bundle config set --local deployment "true"
-      bundle config set --local path "$HOME/.gem"
-      bundle config set --local without "development test code_quality"
-      bundle config set --local suppress_install_using_messages "true"
+    - { src: "bundle-config.j2", dest: "{{ build_path }}/.bundle/config" }
 
 - name: Final notes
   pause:

--- a/roles/fairfood/tasks/main.yml
+++ b/roles/fairfood/tasks/main.yml
@@ -48,11 +48,13 @@
     - { src: "database.yml.j2", dest: "{{ config_path }}/database.yml" }
 
 - name: Configure Bundler
-  shell: |
-    bundle config set --local deployment "true"
-    bundle config set --local path "$HOME/.gem"
-    bundle config set --local without "development test code_quality"
-    bundle config set --local suppress_install_using_messages "true"
+  shell:
+    chdir: "{{ build_path }}"
+    cmd: |
+      bundle config set --local deployment "true"
+      bundle config set --local path "$HOME/.gem"
+      bundle config set --local without "development test code_quality"
+      bundle config set --local suppress_install_using_messages "true"
 
 - name: Final notes
   pause:

--- a/roles/fairfood/tasks/main.yml
+++ b/roles/fairfood/tasks/main.yml
@@ -47,6 +47,13 @@
     - { src: "post-receive.j2", dest: "{{ build_path }}/.git/hooks/post-receive" }
     - { src: "database.yml.j2", dest: "{{ config_path }}/database.yml" }
 
+- name: Configure Bundler
+  shell: |
+    bundle config set --local deployment "true"
+    bundle config set --local path "$HOME/.gem"
+    bundle config set --local without "development test code_quality"
+    bundle config set --local suppress_install_using_messages "true"
+
 - name: Final notes
   pause:
     seconds: 1

--- a/roles/fairfood/templates/bundle-config.j2
+++ b/roles/fairfood/templates/bundle-config.j2
@@ -1,0 +1,6 @@
+---
+BUNDLE_FROZEN: "true"
+BUNDLE_PATH: "{{ app_user_home }}/.gem"
+BUNDLE_DEPLOYMENT: "true"
+BUNDLE_SUPPRESS_INSTALL_USING_MESSAGES: "true"
+BUNDLE_WITHOUT: "development:test:code_quality"

--- a/roles/fairfood/templates/post-receive.j2
+++ b/roles/fairfood/templates/post-receive.j2
@@ -27,7 +27,7 @@ upgrade_application() {
   # Install the required gems
   bundle config set --local deployment "true"
   bundle config set --local path "$HOME/.gem"
-  bundle config set --local without "development test"
+  bundle config set --local without "development test code_quality"
   bundle config set --local suppress_install_using_messages "true"
   bundle install
 

--- a/roles/fairfood/templates/post-receive.j2
+++ b/roles/fairfood/templates/post-receive.j2
@@ -25,10 +25,6 @@ upgrade_application() {
   ./script/install-bundler
 
   # Install the required gems
-  bundle config set --local deployment "true"
-  bundle config set --local path "$HOME/.gem"
-  bundle config set --local without "development test code_quality"
-  bundle config set --local suppress_install_using_messages "true"
   bundle install
 
   ./script/precompile-assets


### PR DESCRIPTION
And set bundle config once instead of every deploy. 

this reduces one line of unnecessary console output, yay! Before:
```
remote: You are replacing the current local value of without, which is currently "development:test"
```

Now slightly cleaner:
```
remote: Already up-to-date: Bundler version 2.6.3
remote: Bundle complete! 86 Gemfile dependencies, 176 gems now installed.
remote: Gems in the groups 'development', 'test' and 'code_quality' were not installed.
remote: Bundled gems are installed into `/srv/fairfood/.gem`
remote: 2 installed gems you directly depend on are looking for funding.
```