### PR TITLE
Favicon redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ environment. This will be loaded only the first time you run ansible on the serv
 
 ```sh
 vagrant up
-ansible-playbook -i hosts -l vagrant site.yml
+ansible-playbook -l vagrant site.yml
 
 # Login to debug:
 vagrant ssh
@@ -58,7 +58,7 @@ Tips for testing individual changes:
  * Go straight to specific task: `--start-at-task='<name of task>'`
  * Run one at a time: `--step`
 
- Eg: `ansible-playbook -i hosts -l vagrant site.yml --step --start-at-task='Install configuration files'`
+ Eg: `ansible-playbook -l vagrant site.yml --step --start-at-task='Install configuration files'`
 
 ### Snapshots
 It's handy to take snapshots to quickly revert back to. Eg:
@@ -106,7 +106,7 @@ ansible-lint site.yml
 
 1. Add the new server to the `hosts` file.
 2. Optionally add public key(s) to `files/admin-ssh-keys`
-3. Run playbook: `ansible-playbook -i hosts -l staging2.ceresfairfood.org.au site.yml -u root --ask-pass` # root user password defaults to Rimu login
+3. Run playbook: `ansible-playbook -l staging2.ceresfairfood.org.au site.yml -u root --ask-pass` # root user password defaults to Rimu login
   - If mysql isn't working, ensure it really did install: `sudo apt-get install libmariadb-dev`
 4. Push codebase and install app: `git push staging` (this must be done before loading data dump, to ensure any recently deleted tables are removed.)
 5. Load database, eg: 
@@ -146,7 +146,7 @@ Choose the latest version of Metabase by setting the variable in `all.yml`.
 
 Use `metabase.yml` playbook, eg:
 ```sh
-ansible-playbook metabase.yml -i hosts -l staging2.ceresfairfood.org.au --ask-become-pass --user <remote-user>
+ansible-playbook metabase.yml -l staging2.ceresfairfood.org.au --ask-become-pass --user <remote-user>
 ```
 
 Default login is example@example.com / metabase123

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,4 @@
 [defaults]
+stdout_callback=debug
 interpreter_python = auto_silent
 inventory = ./hosts

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,3 @@
 [defaults]
 interpreter_python = auto_silent
+inventory = ./hosts

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -182,6 +182,11 @@ nginx_sites_available:
         return 404;
       }
 
+      # some clients look here before reading link rel="icon"
+      location /favicon.ico {
+        return 301 https://$server_name/favicon.png;
+      }
+
       location @unicorn {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;

--- a/hosts
+++ b/hosts
@@ -8,7 +8,6 @@ vagrant ansible_host=127.0.0.1 ansible_port=2222 ansible_user=vagrant ansible_ss
 
 [staging]
 staging.ceresfairfood.org.au https=true developer_email=maikel@openfoodnetwork.org.au
-staging2.ceresfairfood.org.au https=true developer_email=maikel@openfoodnetwork.org.au
 
 [production]
 prod3.ceresfairfood.org.au https=true developer_email=maikel@openfoodnetwork.org.au wormly_hostid=44367 rails_env=production


### PR DESCRIPTION
- arising from ceresfairfood/fairfood-issues#2627

`/favicon.ico` is requested a lot, and is being routed by Rails, using unnecessary resources. Our favicon is defined in the HTML using png which is a way better format. But I think it's some kind of client optimisation that looks ahead when preparing to navigate to a page before it has parsed (or perhaps even requested) the HTML. 

So we can add a hint here which says exactly what the HTML says: load `/favicon.png`.

Also while provisioning I missed a few little niceties from ofn-install and copied them over.
