### PR TITLE
Clean up unused gems after deploy

### DIFF
--- a/roles/fairfood/templates/post-receive.j2
+++ b/roles/fairfood/templates/post-receive.j2
@@ -57,6 +57,9 @@ upgrade_application() {
   # Then save the new version. Don't pipe it directly, because that will create the file before the request and nginx will deliver an empty file.
   wget --content-on-error https://members.ceresfairfood.org.au/500 -O tmp/500.html 2>&1 | egrep -i 'sav|wget:' # reduce output to only include success or fail results.
   mv tmp/500.html public/
+
+  echo "Cleaning up old gems..."
+  bundle clean
 }
 
 while read oldrev newrev refname; do


### PR DESCRIPTION
This will remove any gem versions that are no longer used. I ran it on both staging and prod. It cleaned up about 550mb for the current ruby version. We don't have a way of automatically cleaning up old ruby versions, so it would mean they end up smaller too.

The only risk I can think of is if we needed to revert a gem upgrade after deployment, and for some reason couldn't download/build it again. That seems highly unlikely.
