### PR TITLE
Enable geoip rate limit for fairfood_https

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,18 @@ sudo vim /etc/ssh/sshd_config
 
 ## Repeatable tasks
 
-Most tasks are not designed to be repeated.
+Most tasks were not designed to be repeated, but we are aiming to improve that.
 
 The [add-users](files/admin-ssh-keys/README.md) playbook can be used to add new users.
+Some tasks in the main `site` playbook have tags, which indicates they should be ok to repeat. But make sure any prior changes made on the server are saved in the playbook first.
+
 
 When running tasks as your own user, you need to include `--ask-become-pass` and provide your password.
+It's also advised to check and log diff output first, eg:
+
+```sh
+ansible-playbook site.yml -l staging --ask-become-pass --tags=nginx --diff --check
+```
 
 ## Installing Metabase
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -187,6 +187,8 @@ nginx_sites_available:
         return 301 https://$server_name/favicon.png;
       }
 
+      limit_req zone=overseas burst=70 delay=3;
+
       location @rails {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;


### PR DESCRIPTION
- Follow up from https://github.com/ceresfairfood/fairfood-install/pull/46

I just realised that PR only  updated the config for metabase 🤦 