### PR TITLE
Update post-receive hook

### DIFF
--- a/roles/fairfood/templates/post-receive.j2
+++ b/roles/fairfood/templates/post-receive.j2
@@ -14,6 +14,7 @@ unset GIT_DIR
 # Setup environment
 APP_ROOT="$(pwd)"
 export RAILS_ENV="{{ rails_env }}"
+export DOMAIN="{{ domain }}"
 export JOBS="{{ background_jobs }}"
 
 upgrade_application() {
@@ -52,19 +53,30 @@ upgrade_application() {
   echo "Restart puma..."
   bundle exec pumactl restart # Hot restart helps reduce downtime
 
-  echo "Update the static 500.html page for nginx..."
-  generate_500_page
+  echo "Check homepage" # and abort if any http errors
+  curl -IsS --fail  https://$DOMAIN/ | head -n1
+
+  echo "Update the 404 page static cache..." # for rails
+  generate_page "404"
+
+  echo "Update the 500 page static cache..." # for rails and nginx
+  generate_page "500"
 
   # Clean up any old gems
   bundle clean
+
+  echo "
+    Deployment successful.
+  "
 }
 
-generate_500_page() {
+generate_page() {
   # Delete it first so that nginx is not delivering the old version:
-  rm public/500.html
+  rm -f public/$1.html
   # Then save the new version. Don't pipe it directly, because that will create the file before the request and nginx will deliver an empty file.
-  wget https://members.ceresfairfood.org.au/500 -O tmp/500.html 2>&1 | egrep -i 'saved|wget:|error' # reduce output to only include success or fail results.
-  mv tmp/500.html public/
+  # wget will report an error and we ignore that here.
+  wget --append-output "tmp/wget.log" --content-on-error "https://$DOMAIN/$1" -O "tmp/$1.html" 2>&1 || true
+  mv tmp/$1.html public/
 }
 
 while read oldrev newrev refname; do


### PR DESCRIPTION
- https://github.com/ceresfairfood/fairfood-issues/issues/2670

Add explicit success message for local deploy script to discern success from failure. If any command in the script fails, the script stops and the success message is never printed.