### PR TITLE
Do a full puma restart if the puma gem changed

### DIFF
--- a/roles/fairfood/templates/post-receive.j2
+++ b/roles/fairfood/templates/post-receive.j2
@@ -88,12 +88,18 @@ generate_page() {
 while read oldrev newrev refname; do
   echo "HEAD was at $oldrev"
   if [ "$refname" = "refs/heads/master" ]; then
-    if git diff --quiet "$newrev" -- ".ruby-version"; then
-      # nothing changed
-      restart_mode="hot"
+    # Find out if major dependencies changed
+    set +e
+    git diff --quiet "$newrev" -- ".ruby-version"; ruby_changed=$?
+    git diff "$newrev" -- "Gemfile.lock" | grep -q "\+\s*puma"; puma_unchanged=$? #how to negate this?
+    set -e
+
+    if [[ $ruby_changed -ne 0 || $puma_unchanged -eq 0 ]]; then
+      restart_mode="cold" # Full stop/start
     else
-      restart_mode="cold"
+      restart_mode="hot" # Quicker restart of workers
     fi
+    echo "restart_mode:" $restart_mode
 
     # Checkout the new revision
     git reset --hard "$newrev"


### PR DESCRIPTION
This could probably be refactored but I found bash logic too hard for me!

I created a separate script to test out the conditions, and even so, I couldn't find a way to improve it.
```bash
git checkout master
newrev="07e67233aaf6c29ec2f36c27a31879a494d9c311" #this commit changed nothing -> hot
# newrev="a44108b242144e577952e74f891e0bc390f6fc19~" # changed ruby and puma version -> cold
# newrev="07e67233aaf6c29ec2f36c27a31879a494d9c311~" # changed puma version -> cold

# git checkout -q a44108b242144e577952e74f891e0bc390f6fc19
# newrev="a44108b242144e577952e74f891e0bc390f6fc19~" # changed ruby version only -> cold

####
git diff --quiet "$newrev" -- ".ruby-version"; ruby_changed=$?
git diff "$newrev" -- "Gemfile.lock" | grep -q "\+\s*puma"; puma_unchanged=$? #how to negate this?

if [[ $ruby_changed -ne 0 || $puma_unchanged -eq 0 ]]; then
  restart_mode="cold"
else
  # nothing changed
  restart_mode="hot"
fi
####

git diff "$newrev" --name-only -- ".ruby-version"
echo -e "ruby_changed:" $ruby_changed "\n"

git diff "$newrev" -- "Gemfile.lock" | grep "\+\s*puma"
echo -e "puma_unchanged:" $puma_unchanged "\n"

echo "restart_mode:" $restart_mode

```


