### PR TITLE
Add nginx metrics plugin when migrating servers

### DIFF
--- a/switching-servers.md
+++ b/switching-servers.md
@@ -183,10 +183,12 @@ Most steps are reversible, but not all (switching databases).
 
 **Finishing it off:**
 - [ ] Disable mysql readonly mode on old server if required (eg Wordpress).
+- [ ] `ansible-playbook collectd-wormly.yml -l production --ask-become-pass`
 - [ ] Set up Wormly metrics.
 ```
 apt install collectd
 scp prod3.ceresfairfood.org.au:/etc/collectd/collectd.conf.d/wormly.conf /etc/collectd/collectd.conf.d/
+scp prod3.ceresfairfood.org.au:/etc/collectd/collectd.conf.d/monitor-nginx.conf /etc/collectd/collectd.conf.d/
 ssh prod3.ceresfairfood.org.au "systemctl stop collectd.service"
 systemctl restart collectd.service
 ```

--- a/switching-servers.md
+++ b/switching-servers.md
@@ -191,6 +191,8 @@ scp prod3.ceresfairfood.org.au:/etc/collectd/collectd.conf.d/wormly.conf /etc/co
 scp prod3.ceresfairfood.org.au:/etc/collectd/collectd.conf.d/monitor-nginx.conf /etc/collectd/collectd.conf.d/
 ssh prod3.ceresfairfood.org.au "systemctl stop collectd.service"
 systemctl restart collectd.service
+# Schedule daily restart (run as root)
+(crontab -l ; echo "01 01 * * * systemctl restart collectd")| crontab -
 ```
 - [ ] Check metrics at https://www.wormly.com/jsgraphs/jsgraphpageid/424045.
 - [ ] Update post-receive hook on old server:


### PR DESCRIPTION
I discovered today that the nginx metrics weren't being logged. When I set them up I didn't add them to the main playbook, so they didn't get set up on the new server.