### PR TITLE
Avoid unnecessary email error

### DIFF
--- a/roles/mail/tasks/main.yml
+++ b/roles/mail/tasks/main.yml
@@ -23,7 +23,7 @@
     create: yes
     dest: ~/.forward
     regexp: "root"
-    line: "{{ email_it }}, /root/mailbox"
+    line: "{{ email_it }}"
     state: present
 
 # Check for email delivery errors and email details to admins

--- a/roles/mail/tasks/main.yml
+++ b/roles/mail/tasks/main.yml
@@ -22,7 +22,6 @@
   lineinfile:
     create: yes
     dest: ~/.forward
-    regexp: "root"
     line: "{{ email_it }}"
     state: present
 


### PR DESCRIPTION
It caused errors in the postfix logs, yet the email was still delivered to email_it.

    cannot append message to file /root/mailbox: cannot open file: Permission denied

There's no mailbox there, it's actually at `/var/mail/root`. But changing to that path yields the same error. We don't need to specify it at all, so I removed it.

* Manually updated on prod already while testing
* Provisioned to staging already
