### PR TITLE
Install puma user service file

### DIFF
--- a/roles/app-user/tasks/main.yml
+++ b/roles/app-user/tasks/main.yml
@@ -18,6 +18,11 @@
     dest: "/etc/sudoers.d/{{ app_user }}"
     mode: 0440
 
+- name: Create user's systemd service config directory
+  file:
+    path: "{{ app_user_home }}/.config/systemd/user"
+    state: "directory"
+
 # This only works with a root login. Switching via sudo doesn't allow access.
 - name: Allow user to run services without login
   shell: loginctl enable-linger {{ app_user }}

--- a/roles/jobs/tasks/main.yml
+++ b/roles/jobs/tasks/main.yml
@@ -5,9 +5,7 @@
     src: "solid-queue.service.j2"
     dest: "{{ app_user_home }}/.config/systemd/user/jobs-{{ app }}.service"
 
-# # This doesn't work because of a missing dbus session.
-# # But the post-receive hook can do it during deploy.
-# - name: Enable jobs at boot
-#   shell: bash -lc "systemctl --user enable jobs-{{ app }}.service"
-#   args:
-#     creates: "{{ app_user_home }}/.config/systemd/user/default.target.wants/jobs-{{ app }}.service"
+- name: Enable jobs at boot
+  shell: systemctl --user --machine={{ app_user }}@.host enable jobs-{{ app }}.service
+  args:
+    creates: "{{ app_user_home }}/.config/systemd/user/default.target.wants/jobs-{{ app }}.service"

--- a/roles/jobs/tasks/main.yml
+++ b/roles/jobs/tasks/main.yml
@@ -1,10 +1,5 @@
 ---
 
-- name: Create user's systemd service config directory
-  file:
-    path: "{{ app_user_home }}/.config/systemd/user"
-    state: "directory"
-
 - name: Install Solid Queue job workers service
   template:
     src: "solid-queue.service.j2"

--- a/roles/puma/handlers/main.yml
+++ b/roles/puma/handlers/main.yml
@@ -1,4 +1,0 @@
----
-- name: "restart puma"
-  service: name=puma-{{ app }} state=restarted
-  become: yes

--- a/roles/puma/tasks/main.yml
+++ b/roles/puma/tasks/main.yml
@@ -1,23 +1,13 @@
 ---
 # Install puma app service
 
-- name: copy puma files
+- name: Install puma service
   template:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
-    mode: "0744"
-    owner: "{{ app_user }}"
-    group: "{{ app_user }}"
-  become: yes
-  with_items:
-    # Any updates to the puma init script need to be reloaded: systemctl daemon-reload
-    - { src: "puma.service.j2", dest: "/etc/systemd/system/puma-{{ app }}.service" }
-  notify:
-    - restart nginx
-    - restart puma
+    src: "puma.service.j2"
+    dest: "{{ app_user_home }}/.config/systemd/user/puma.service"
 
-- name: enable puma at boot
-  service:
-    name=puma-{{ app }}
-    enabled=yes
-  become: yes
+- name: Enable puma at boot
+  shell: systemctl --user --machine={{ app_user }}@.host enable puma.service
+  args:
+    creates: "{{ app_user_home }}/.config/systemd/user/multi-user.target.wants/puma.service"
+  become: true

--- a/roles/puma/templates/puma.service.j2
+++ b/roles/puma/templates/puma.service.j2
@@ -6,7 +6,6 @@ After=network.target
 
 [Service]
 Type=simple
-User={{ app_user }}
 
 WorkingDirectory={{ current_path }}
 PIDFile={{ puma_pid }}


### PR DESCRIPTION
We should probably remove the system service file after the successful switch to avoid confusion. The main advantage of the user service is that we don't need sudo to control it. And we can use any systemd command for that service when logged in as fairfood. The downside is that it's slightly more annoying to control the service when switching users.

This has been tested on staging already. After this is installed, we can switch the puma processes as root:

```
systemctl daemon-reload
systemctl stop puma-fairfood.service && systemctl --user --machine=fairfood@.host start puma.service
systemctl disable puma-fairfood.service
```

We also need to update our restart script in the app repository:

- https://github.com/ceresfairfood/fairfood/pull/2630