### PR TITLE
Fix starting puma at boot time

### DIFF
--- a/roles/puma/tasks/main.yml
+++ b/roles/puma/tasks/main.yml
@@ -9,5 +9,5 @@
 - name: Enable puma at boot
   shell: systemctl --user --machine={{ app_user }}@.host enable puma.service
   args:
-    creates: "{{ app_user_home }}/.config/systemd/user/multi-user.target.wants/puma.service"
+    creates: "{{ app_user_home }}/.config/systemd/user/default.target.wants/puma.service"
   become: true

--- a/roles/puma/templates/puma.service.j2
+++ b/roles/puma/templates/puma.service.j2
@@ -29,4 +29,4 @@ RestartSec=30s
 TimeoutSec=30s
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
It looks like the `multi-user` target is not run by the user process of systemd. It kind of makes sense. That was just the default before.

This has been tested on staging and applied to production as well:
```
systemctl disable --user puma.service
systemctl --user daemon-reload
systemctl enable --user puma.service
```
