### PR TITLE
Use Puma's support of the notify feature and watchdog

### DIFF
--- a/roles/fairfood/templates/post-receive.j2
+++ b/roles/fairfood/templates/post-receive.j2
@@ -57,6 +57,7 @@ upgrade_application() {
   echo "Restart puma..."
   StartDate=$(date -u +"%s")
   ./script/restart-puma "$restart_mode"
+  systemctl --user enable "puma.service"
 
   echo "Check homepage" # connect and retry transient errors (5xx) up to 10 seconds, abort script if errors persist
   curl --head --silent --show-error --fail --connect-timeout 10 --retry 10 --retry-delay 1 "https://$DOMAIN/" | head -n1

--- a/roles/jobs/tasks/main.yml
+++ b/roles/jobs/tasks/main.yml
@@ -4,8 +4,3 @@
   template:
     src: "solid-queue.service.j2"
     dest: "{{ app_user_home }}/.config/systemd/user/jobs-{{ app }}.service"
-
-- name: Enable jobs at boot
-  shell: systemctl --user --machine={{ app_user }}@.host enable jobs-{{ app }}.service
-  args:
-    creates: "{{ app_user_home }}/.config/systemd/user/default.target.wants/jobs-{{ app }}.service"

--- a/roles/puma/tasks/main.yml
+++ b/roles/puma/tasks/main.yml
@@ -5,3 +5,8 @@
   template:
     src: "puma.service.j2"
     dest: "{{ app_user_home }}/.config/systemd/user/puma.service"
+
+- name: Install puma socket
+  template:
+    src: "puma.socket.j2"
+    dest: "{{ app_user_home }}/.config/systemd/user/puma.socket"

--- a/roles/puma/tasks/main.yml
+++ b/roles/puma/tasks/main.yml
@@ -5,9 +5,3 @@
   template:
     src: "puma.service.j2"
     dest: "{{ app_user_home }}/.config/systemd/user/puma.service"
-
-- name: Enable puma at boot
-  shell: systemctl --user --machine={{ app_user }}@.host enable puma.service
-  args:
-    creates: "{{ app_user_home }}/.config/systemd/user/default.target.wants/puma.service"
-  become: true

--- a/roles/puma/templates/puma.service.j2
+++ b/roles/puma/templates/puma.service.j2
@@ -23,6 +23,13 @@ Environment=LOGFILE="{{ puma_log }}"
 
 ExecStart={{ app_user_home }}/.rbenv/shims/bundle exec puma -C {{ puma_config }}
 
+# Hot restart
+# - keeps connections
+# - allows safe puma upgrade
+# - does not allow upgrading Ruby though, use restart instead
+# - https://github.com/puma/puma/blob/main/docs/restart.md
+ExecReload=/bin/kill -SIGUSR2 $MAINPID
+
 Restart=always
 
 [Install]

--- a/roles/puma/templates/puma.service.j2
+++ b/roles/puma/templates/puma.service.j2
@@ -21,7 +21,7 @@ Environment=LOGFILE="{{ puma_log }}"
 # Helpful for debugging socket activation, etc.
 # Environment=PUMA_DEBUG=1
 
-ExecStart=/bin/bash -lc "bundle exec puma -C {{ puma_config }}"
+ExecStart={{ app_user_home }}/.rbenv/shims/bundle exec puma -C {{ puma_config }}
 
 Restart=always
 

--- a/roles/puma/templates/puma.service.j2
+++ b/roles/puma/templates/puma.service.j2
@@ -22,7 +22,6 @@ Environment=LOGFILE="{{ puma_log }}"
 # Environment=PUMA_DEBUG=1
 
 ExecStart=/bin/bash -lc "bundle exec puma -C {{ puma_config }}"
-ExecReload=/bin/bash -lc "bundle exec pumactl phased-restart -S {{ puma_state }}"
 
 Restart=always
 

--- a/roles/puma/templates/puma.service.j2
+++ b/roles/puma/templates/puma.service.j2
@@ -5,7 +5,8 @@ Description=Puma HTTP Server
 After=network.target
 
 [Service]
-Type=simple
+Type=notify
+WatchdogSec=10
 
 WorkingDirectory={{ current_path }}
 PIDFile={{ puma_pid }}
@@ -23,10 +24,7 @@ Environment=LOGFILE="{{ puma_log }}"
 ExecStart=/bin/bash -lc "bundle exec puma -C {{ puma_config }}"
 ExecReload=/bin/bash -lc "bundle exec pumactl phased-restart -S {{ puma_state }}"
 
-SyslogIdentifier=puma
-Restart=on-failure
-RestartSec=30s
-TimeoutSec=30s
+Restart=always
 
 [Install]
 WantedBy=default.target

--- a/roles/puma/templates/puma.socket.j2
+++ b/roles/puma/templates/puma.socket.j2
@@ -1,0 +1,25 @@
+# Ansible managed
+
+# This systemd socket listener allows zero-downtime puma service restarts.
+#
+# We can now perform a cold restart, for example when upgrading Ruby, while
+# systemd keeps listening to the socket and clients just wait until puma is
+# up again.
+#
+# - https://github.com/puma/puma/blob/main/docs/systemd.md
+
+[Unit]
+Description=Puma HTTP Server Accept Sockets
+
+[Socket]
+ListenStream={{ puma_sock }}
+
+# Socket options matching Puma defaults
+ReusePort=true
+Backlog=1024
+# Enable this if you're using Puma with the "low_latency" option, read more in Puma DSL docs and systemd docs:
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.socket.html#NoDelay=
+# NoDelay=true
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
Also start the service more directly and implement our current practise of hot restarts.

The changes were inspired by:

- https://github.com/puma/puma/blob/main/docs/systemd.md
- https://world.hey.com/robzolkos/how-i-deploy-solid-queue-with-capistrano-487b4a31

And then I finally added the systemd socket listener for us to try out. I tested it on staging and got _zero downtime_ restarts. This makes puma's hot restart obsolete, really. The only advantage would be to keep the same PID on the puma master process but who cares about that when systemd manages everything?

I think that we should do this socket thing for OFN as well and then we don't even need to bother with hot restarts there. But I'm still learning...