### PR TITLE
Don't start the graceful job stop until after ruby is installed

### DIFF
--- a/roles/fairfood/templates/post-receive.j2
+++ b/roles/fairfood/templates/post-receive.j2
@@ -23,11 +23,11 @@ upgrade_application() {
 
   echo "RAILS_ENV=$RAILS_ENV"
 
-  echo "Stop job workers gracefully..."
-  systemctl --user --no-block stop "jobs-{{ app }}.service"
-
   source script/rbenv-init.sh
   ./script/rbenv-install.sh
+
+  echo "Stop job workers gracefully..."
+  systemctl --user --no-block stop "jobs-{{ app }}.service"
 
   # Install the required gems
   bundle install


### PR DESCRIPTION
It can take a long time, and we want to let jobs continue to start during that time. Particularly time-sensitive ones like emails.

- https://openfoodnetwork.slack.com/archives/C02L526B7H8/p1779770512763769
