### PR TITLE
Add admin users to adm group to read logs

### DIFF
--- a/roles/admin-users/tasks/main.yml
+++ b/roles/admin-users/tasks/main.yml
@@ -7,7 +7,9 @@
     name: "{{ item | basename | splitext | first }}"
     state: present
     append: yes
-    groups: sudo
+    groups:
+      - adm
+      - sudo
     shell: /bin/bash
     # Password login is disabled by default.
     # Set a user's password after SSH has been configured for key authentication


### PR DESCRIPTION
- Closes #7

Tested and applied to staging and production.

_P.S.: This is closing the last issue on this repository. All issues should then be in fairfood-issues and we can disable the feature here._
