### PR TITLE
Reduce request rate from overseas to protect server

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -182,7 +182,7 @@ nginx_sites_available:
         return 301 https://$server_name/favicon.png;
       }
 
-      limit_req zone=overseas burst=70 delay=3;
+      limit_req zone=overseas burst=50 delay=3;
 
       location @rails {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -288,4 +288,4 @@ nginx_configs:
     - |
       geoip2 /usr/share/GeoIP/GeoLite2-Country.mmdb { $geoip2_data_country_iso_code country iso_code; }
       map $geoip2_data_country_iso_code  $geo_outside_aus { default "outside"; AU ""; }
-      limit_req_zone $geo_outside_aus zone=overseas:10m rate=150r/m;
+      limit_req_zone $geo_outside_aus zone=overseas:10m rate=100r/m;


### PR DESCRIPTION
A recent scan made our server unavailable. I triggered our rate limitting but the server was maxed out and couldn't respond to Wormly anymore. It was a busy time for customers ordering as well.

I applied this manually to prod already.

What I shared on Slack before:

> This was the outage affecting the shop together with the Wordpress site. I can see a spike in ningx requests in Wormly and a spike in CPU usage, mainly system and elevated IO use with reading from swap.
> 
> In the ten minutes before 7pm, there were twice as many requests as before and after. Same amount of IP addresses though.
> 
> One IP address from Singapore made 581 in ten minutes. And that were all the requests it made. It was scanning for secrets and tried common paths like /appsettings.json  and many other paths with differing user agents.
> 
> At some point our firewall kicked in and blocked it. 20 requests were blocked before it gave up and stopped.
> 
> Wormly wasn't blocked. It observed timeouts trying to connect. So given that CPU use went to 100% and the site wasn't reachable by Wormly, we should probably reduce the amount of requests we allow from outside Australia. It look like we allowed more than our server can handle.


