### PR TITLE
Start puma after Mariadb and stop if before

### DIFF
--- a/roles/puma/templates/puma.service.j2
+++ b/roles/puma/templates/puma.service.j2
@@ -2,7 +2,7 @@
 
 [Unit]
 Description=Puma HTTP Server
-After=network.target
+After=network.target mariadb.service
 Requires=puma.socket
 
 [Service]


### PR DESCRIPTION
This should avoid database errors during reboots.

- https://github.com/ceresfairfood/fairfood-issues/issues/2857

We also have the option to "require" mariadb in systemd.

> If MariaDB fails to start, Puma won't start either.
> If MariaDB stops or crashes later, systemd will pull Puma down too.

I don't think that this would be useful. It actually helps to receive an error report from the Rails app and we may be able to display something without the database. That said, I got an unstyled error message on staging when I stopped the database. We could probably improve that. But for now it's probably better to keep puma running while we try to fix mariadb.

