### PR TITLE
Reduce overseas rate limit

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -182,6 +182,8 @@ nginx_sites_available:
         return 301 https://$server_name/favicon.png;
       }
 
+      # Bursts of up to 3 requests allowed. Further reqs are queued and delayed as per rate limit.
+      # If the burst exceeds 50 requests, they will be rejected immediately with code 503.
       limit_req zone=overseas burst=50 delay=3;
 
       location @rails {
@@ -284,6 +286,8 @@ nginx_configs:
         default "";
       }
 
+  # Rate limiting for overseas traffic. A max rate of 100requests/min is permitted.
+  # See the server block above for burst and delay rules.
   geoip:
     - |
       geoip2 /usr/share/GeoIP/GeoLite2-Country.mmdb { $geoip2_data_country_iso_code country iso_code; }

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -183,9 +183,9 @@ nginx_sites_available:
       }
 
       # First 3 excess requests pass through immediately (no delay).
-      # The next requests, up to the burst=50 total, are queued/delayed to enforce the 100r/m rate.
+      # The next requests, up to the burst=30 total, are queued/delayed to enforce the 80r/m rate.
       # Further excess requests are rejected immediately with 503.
-      limit_req zone=overseas burst=50 delay=3;
+      limit_req zone=overseas burst=30 delay=2;
 
       location @rails {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -293,4 +293,4 @@ nginx_configs:
     - |
       geoip2 /usr/share/GeoIP/GeoLite2-Country.mmdb { $geoip2_data_country_iso_code country iso_code; }
       map $geoip2_data_country_iso_code  $geo_outside_aus { default "outside"; AU ""; }
-      limit_req_zone $geo_outside_aus zone=overseas:10m rate=100r/m;
+      limit_req_zone $geo_outside_aus zone=overseas:10m rate=80r/m;

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -182,8 +182,9 @@ nginx_sites_available:
         return 301 https://$server_name/favicon.png;
       }
 
-      # Bursts of up to 3 requests allowed. Further reqs are queued and delayed as per rate limit.
-      # If the burst exceeds 50 requests, they will be rejected immediately with code 503.
+      # First 3 excess requests pass through immediately (no delay).
+      # The next requests, up to the burst=50 total, are queued/delayed to enforce the 100r/m rate.
+      # Further excess requests are rejected immediately with 503.
       limit_req zone=overseas burst=50 delay=3;
 
       location @rails {
@@ -286,7 +287,7 @@ nginx_configs:
         default "";
       }
 
-  # Rate limiting for overseas traffic. A max rate of 100requests/min is permitted.
+  # General rate limiting shared for all overseas traffic.
   # See the server block above for burst and delay rules.
   geoip:
     - |


### PR DESCRIPTION
- https://github.com/ceresfairfood/fairfood-issues/issues/2853

### Testing
Claude gave me a handy script which I adjusted. It sent out 40 requests all at once.
30 were queued, while 10 were immediately rejected as 503. The queued ones trickled through and were done after 22 seconds (I think this is a little slower than 80 requests per minute).

I was able to browse the site at the same time from two different browser sessions and checkout. Yay!

```
openfoodnetwork@uk-staging:~$ set +m
openfoodnetwork@uk-staging:~$ URL="https://staging.ceresfairfood.org.au/"
openfoodnetwork@uk-staging:~$ date; for i in $(seq 1 40); do   curl -o /dev/null -s -w "Request $i: %{http_code}\n" "$URL" & done; wait; date
Tue Jul 21 07:14:32 UTC 2026
Request 15: 503
Request 20: 503
Request 27: 503
Request 33: 503
Request 39: 503
Request 26: 503
Request 22: 503
Request 12: 503
Request 11: 503
Request 21: 200
Request 3: 200
Request 1: 200
Request 14: 200
Request 9: 200
...
Request 32: 200
Tue Jul 21 07:14:54 UTC 2026
```

Also tried with `URL="https://staging.ceresfairfood.org.au/.env"`
It took 23 seconds to return the 404s.

When I did the same script locally, it was able to return all the 404s in only 6 seconds.