### PR TITLE
Don't rate limit NZ IPs

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -292,5 +292,9 @@ nginx_configs:
   geoip:
     - |
       geoip2 /usr/share/GeoIP/GeoLite2-Country.mmdb { $geoip2_data_country_iso_code country iso_code; }
-      map $geoip2_data_country_iso_code  $geo_outside_aus { default "outside"; AU ""; }
+      map $geoip2_data_country_iso_code $geo_outside_aus {
+        default "outside";
+        AU "";
+        NZ "";
+      }
       limit_req_zone $geo_outside_aus zone=overseas:10m rate=80r/m;


### PR DESCRIPTION
Our server is likely detected as NZ because the IP is owned by a NZ company. Anyway we're less likely to have overactive bots coming from NZ, where data centres are probably more expensive than AU.

- Fixes ceresfairfood/fairfood-issues#2853


Deployed on staging. But the fix isn't observable until we deploy to prod where WP is hosted.
(note that Wordpress' nginx config refers to this shared `geoip` config).


I proved that the server is treated as overseas (NZ):
* staging curl -> prod - _rate limited_ 
* prod curl -> staging (with this fix) - _not rate limited_