### PR TITLE
Permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,11 @@ The [add-users](files/admin-ssh-keys/README.md) playbook can be used to add new 
 Some tasks in the main `site` playbook have tags, which indicates they should be ok to repeat. But make sure any prior changes made on the server are saved in the playbook first.
 
 
-When running tasks as your own user, you need to include `--ask-become-pass` and provide your password.
-It's also advised to check and log diff output first, eg:
+When running tasks as your own user, you need to include `--ask-become-pass` (shortcut `-K`) and provide your password.
+It's also advised to `--check` (`-C`, ie "dry run") and log `--diff` (`-D`) output first, eg:
 
 ```sh
-ansible-playbook site.yml -l staging --ask-become-pass --tags=nginx --diff --check
+ansible-playbook site.yml -l staging -K -t nginx -DC
 ```
 
 ## Installing Metabase

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -17,7 +17,7 @@ build_path: "{{ current_path }}"
 
 log_path: "{{ current_path }}/log"
 pid_path: "{{ current_path }}/tmp/pids"
-sock_path: "{{ current_path }}/tmp/socks"
+sock_path: "/tmp/socks"
 
 # During [prod switchover](README.md#switching-servers),
 # domain will be manually updated in nginx config, and new certs generated.

--- a/roles/fairfood/templates/database.yml.j2
+++ b/roles/fairfood/templates/database.yml.j2
@@ -1,3 +1,5 @@
+# Ansible managed
+
 staging:
   adapter: mysql2
   encoding: utf8

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -1,11 +1,5 @@
 ---
 
-- name: Allow nginx to access app directory
-  user:
-    name: www-data
-    groups: "{{ app_user }}"
-    append: yes
-
 # Check config and report to wormly if invalid.
 # This ensures we are always ready to start nginx in the event of a system restart.
 - name: Install nginx config check script


### PR DESCRIPTION
- Closes ceresfairfood/fairfood-issues#2873

Is it ok to live in the `/tmp` folder? If not, I guess we'd need to create some other folder that can be safely shared.

Provisioned only on staging so far:
```
 pb site.yml -l staging -K -t fairfood,puma,nginx,jobs -D
```

I manually removed the permission from `/etc/group` on staging. Ansible doesn't have a built-in method for that anyway.
```diff
- fairfood:x:1001:www-data
+ fairfood:x:1001:
```

I note that the `current` folder still appears to give read permission for all other users: (isn't that what the last `r` means?) 
```
root@staging3:/home/david# ls -la /srv/fairfood/current/
total 288
drwxrwxr-x 18 fairfood fairfood   4096 Jul 25 14:34 .
drwx--x--- 10 fairfood fairfood   4096 Aug  3 14:44 ..
...
```

But can confirm that nginx, which uses `www-data`, can't access it. Maybe because the parent folder doesn't allow read access?
```
david@staging3:~$ sudo -u www-data cat /srv/fairfood/current/config/database.yml
[sudo] password for david:
cat: /srv/fairfood/current/config/database.yml: Permission denied
```